### PR TITLE
Fixed sourcemaps, fixes #11

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## History
 
+- v2.4.3 July 2, 2014
+  - Fixed [#11](https://github.com/jking90/docpad-plugin-nodesass/issues/11)
+  - Removed mkdirp as a dependency
+  - Switched from writing `.map` file to disk to including it as a data URI
+
 - v2.4.2 June 16, 2014
   - Implemented `precision` option (fixed [#10](https://github.com/jking90/docpad-plugin-nodesass/issues/10))
   - Updated [node-sass](https://github.com/andrew/node-sass) to [0.9.3](https://github.com/andrew/node-sass/releases/tag/v0.9.3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpad-plugin-nodesass",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Adds support for the Sass CSS pre-processor to DocPad using node-sass",
   "homepage": "https://github.com/jking90/docpad-plugin-nodesass",
   "keywords": [
@@ -44,8 +44,7 @@
     "taskgroup": "~3.4.0",
     "node-sass": "^0.9.3",
     "node-bourbon": "~1.2.3",
-    "node-neat": "~1.3.0",
-    "mkdirp": "~0.5.0"
+    "node-neat": "~1.3.0"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",

--- a/test/docpad.js
+++ b/test/docpad.js
@@ -3,8 +3,8 @@ module.exports = {
     nodesass: {
       imagePath: '/path/to/images',
       neat: true,
-      precision: 3,
-      outputStyle: 'compressed'
+      outputStyle: 'compressed',
+      precision: 3
     }
   }
 };


### PR DESCRIPTION
Tried adding `debugInfo: map` to the test `docpad.js`, but it broke the test suite. Not sure why.
